### PR TITLE
Fix latest builds by adding tree-sitter as dependency

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,16 +2,34 @@ let
   sources = import ./nix/sources.nix;
   nixpkgs = sources."nixpkgs-unstable";
   pkgs = import nixpkgs { };
+
+  # Needed until https://github.com/NixOS/nixpkgs/pull/102763 lands in nixpkgs-unstable
+  tree-sitter = pkgs.tree-sitter.overrideAttrs (oldAttrs: {
+    version = "0.17.3";
+    sha256 = "sha256-uQs80r9cPX8Q46irJYv2FfvuppwonSS5HVClFujaP+U=";
+    cargoSha256 = "sha256-fonlxLNh9KyEwCj7G5vxa7cM/DlcHNFbQpp0SwVQ3j4=";
+
+    postInstall = ''
+      PREFIX=$out make install
+    '';
+
+    buildInputs = oldAttrs.buildInputs
+      ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.darwin.apple_sdk.frameworks.Security ];
+
+    meta = oldAttrs.meta // { broken = false; };
+  });
 in
 _: _:
 {
   neovim-nightly = pkgs.neovim-unwrapped.overrideAttrs (
-    _: {
+    old: {
       pname = "neovim-nightly";
       version = "master";
       src = pkgs.fetchFromGitHub {
         inherit (sources.neovim) owner repo rev sha256;
       };
+
+      buildInputs = old.buildInputs ++ [ tree-sitter ];
     }
   );
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,11 +17,12 @@
         "homepage": "https://neovim.io",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "5b5848f2fb1f4b7995bb8a59d94b6766d2182070",
-        "sha256": "01r3i0l2bizk0rn58ryg2z6kmxx857jwm1bg6r2g5msgacw21jga",
+        "rev": "5161ff88fa6b7464fc9554b5d456bd08e3644ace",
+        "sha256": "1fcn17l830q7cp8cw0d8sgafl8s4m6z636asv73s58aawahzqxd3",
         "type": "tarball",
-        "url": "https://github.com/neovim/neovim/archive/5b5848f2fb1f4b7995bb8a59d94b6766d2182070.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+        "url": "https://github.com/neovim/neovim/archive/5161ff88fa6b7464fc9554b5d456bd08e3644ace.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
+        "version": "0fce70252d8e5ccf4cb6f141d1c388966f9f3482"
     },
     "nixpkgs": {
         "branch": "nixos-20.03",
@@ -29,22 +30,22 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "504f993df9a5ca63317fe9c859df19daad30aa14",
-        "sha256": "19innk4v45xq62q6n5h0alhfbb3v7yxpdd1r7sglgjn8sr3ylwmn",
+        "rev": "0bf298df24f721a7f85c580339fb7eeff64b927c",
+        "sha256": "0kdx3pz0l422d0vvvj3h8mnq65jcg2scb13dc1z1lg2a8cln842z",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/504f993df9a5ca63317fe9c859df19daad30aa14.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/0bf298df24f721a7f85c580339fb7eeff64b927c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-unstable": {
         "branch": "nixpkgs-unstable",
-        "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
+        "description": "Nix Packages collection",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
-        "repo": "nixpkgs-channels",
-        "rev": "502845c3e31ef3de0e424f3fcb09217df2ce6df6",
-        "sha256": "0fcqpsy6y7dgn0y0wgpa56gsg0b0p8avlpjrd79fp4mp9bl18nda",
+        "repo": "nixpkgs",
+        "rev": "0da76dab4c2acce5ebf404c400d38ad95c52b152",
+        "sha256": "1lj3h4hg3cnxl3avbg9089wd8c82i6sxhdyxfy99l950i78j0gfg",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/502845c3e31ef3de0e424f3fcb09217df2ce6df6.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/0da76dab4c2acce5ebf404c400d38ad95c52b152.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks.nix": {
@@ -53,10 +54,10 @@
         "homepage": "",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "117579f3cfe4c0abeff70631fa31261d5ea99cfd",
-        "sha256": "1bjvadx76rlf54b43agfx1w35wqpagzihdv2yy0jsrk1glxc15ax",
+        "rev": "ff137b7c39681b2eeeaa9bbbf86a03891099ae46",
+        "sha256": "0a8ivc1xgxlf3w9m740z9z3cgdb0hfh0yx4nd3nli8dmaxr55cms",
         "type": "tarball",
-        "url": "https://github.com/cachix/pre-commit-hooks.nix/archive/117579f3cfe4c0abeff70631fa31261d5ea99cfd.tar.gz",
+        "url": "https://github.com/cachix/pre-commit-hooks.nix/archive/ff137b7c39681b2eeeaa9bbbf86a03891099ae46.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
* The latest neovim master branch doesn't build without the tree-sitter
  dependency
* Also track NixOS/nixpkgs instead of the deprecated
  NixOS/nixpkgs-channels repo