### PR TITLE
Use tree-sitter version from nixpkgs-unstable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,34 +2,14 @@ let
   sources = import ./nix/sources.nix;
   nixpkgs = sources."nixpkgs-unstable";
   pkgs = import nixpkgs { };
-
-  # Needed until https://github.com/NixOS/nixpkgs/pull/102763 lands in nixpkgs-unstable
-  tree-sitter = pkgs.tree-sitter.overrideAttrs (oldAttrs: {
-    version = "0.17.3";
-    sha256 = "sha256-uQs80r9cPX8Q46irJYv2FfvuppwonSS5HVClFujaP+U=";
-    cargoSha256 = "sha256-fonlxLNh9KyEwCj7G5vxa7cM/DlcHNFbQpp0SwVQ3j4=";
-
-    postInstall = ''
-      PREFIX=$out make install
-    '';
-
-    buildInputs = oldAttrs.buildInputs
-      ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.darwin.apple_sdk.frameworks.Security ];
-
-    meta = oldAttrs.meta // { broken = false; };
-  });
 in
 _: _:
 {
-  neovim-nightly = pkgs.neovim-unwrapped.overrideAttrs (
-    old: {
-      pname = "neovim-nightly";
-      version = "master";
-      src = pkgs.fetchFromGitHub {
-        inherit (sources.neovim) owner repo rev sha256;
-      };
+  neovim-nightly = pkgs.neovim-unwrapped.overrideAttrs (oldAttrs: {
+    pname = "neovim-nightly";
+    version = "master";
+    src = sources.neovim;
 
-      buildInputs = old.buildInputs ++ [ tree-sitter ];
-    }
-  );
+    buildInputs = oldAttrs.buildInputs ++ [ pkgs.tree-sitter ];
+  });
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -42,10 +42,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0da76dab4c2acce5ebf404c400d38ad95c52b152",
-        "sha256": "1lj3h4hg3cnxl3avbg9089wd8c82i6sxhdyxfy99l950i78j0gfg",
+        "rev": "a371c1071161104d329f6a85d922fd92b7cbab63",
+        "sha256": "1k5wa16wyb1byk5xfjlq4m518gsw6g1kypx4xb09k3inni13p0r4",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/0da76dab4c2acce5ebf404c400d38ad95c52b152.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a371c1071161104d329f6a85d922fd92b7cbab63.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks.nix": {


### PR DESCRIPTION
Stop pinning `tree-sitter` manually now that NixOS/nixpkgs#102763 has landed