### PR TITLE
Use tree-sitter version from nixpkgs-unstable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,22 +2,6 @@ let
   sources = import ./nix/sources.nix;
   nixpkgs = sources."nixpkgs-unstable";
   pkgs = import nixpkgs { };
-
-  # Needed until https://github.com/NixOS/nixpkgs/pull/102763 lands in nixpkgs-unstable
-  tree-sitter = pkgs.tree-sitter.overrideAttrs (oldAttrs: {
-    version = "0.17.3";
-    sha256 = "sha256-uQs80r9cPX8Q46irJYv2FfvuppwonSS5HVClFujaP+U=";
-    cargoSha256 = "sha256-fonlxLNh9KyEwCj7G5vxa7cM/DlcHNFbQpp0SwVQ3j4=";
-
-    postInstall = ''
-      PREFIX=$out make install
-    '';
-
-    buildInputs = oldAttrs.buildInputs
-      ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.darwin.apple_sdk.frameworks.Security ];
-
-    meta = oldAttrs.meta // { broken = false; };
-  });
 in
 _: _:
 {
@@ -27,7 +11,7 @@ _: _:
       version = "master";
       src = sources.neovim;
 
-      buildInputs = old.buildInputs ++ [ tree-sitter ];
+      buildInputs = old.buildInputs ++ [ pkgs.tree-sitter ];
     }
   );
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -30,10 +30,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f41c0fc7d8e49d94220f74495d4d702922df2a67",
-        "sha256": "01wim7ayn69y056q28ifw2f0mdypidpc0z15dda54aj5yy5vai09",
+        "rev": "14cf906f33c39d38741062df2cca0b0575b210ff",
+        "sha256": "1fmjn8ps072kqm9jm3bpcxjj2h6a3f25rh2bcj62ml1a1m397nkb",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/f41c0fc7d8e49d94220f74495d4d702922df2a67.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/14cf906f33c39d38741062df2cca0b0575b210ff.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-unstable": {
@@ -42,10 +42,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dd1b7e377f6d77ddee4ab84be11173d3566d6a18",
-        "sha256": "158zx28wfxqkv51lwgkbsdp1v3wyijp6crmk3mkvqa0v0619yxiv",
+        "rev": "4f3475b113c93d204992838aecafa89b1b3ccfde",
+        "sha256": "158iik656ds6i6pc672w54cnph4d44d0a218dkq6npzrbhd3vvbg",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/dd1b7e377f6d77ddee4ab84be11173d3566d6a18.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/4f3475b113c93d204992838aecafa89b1b3ccfde.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks.nix": {


### PR DESCRIPTION
* Stop pinning tree-sitter manually now that NixOS/nixpkgs#102763 has landed and
hydra has caught up
* I explicitly ran `niv update` before making the change (as opposed to manually pinning to a `nixpkgs-unstable` commit), which means the change won't accidentally get reverted the next time the niv automation runs